### PR TITLE
Implement show and other data-preview methods on TSDF and also select…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ The purpose of this project is to make time series manipulation with Spark simpl
 
 Python - pip install in Databricks notebooks using:
 
-```
+```shell
 %pip install dbl-tempo
 ```
 
 Install locally using: 
 
-```
+```shell
 pip install dbl-tempo
 ```
 
@@ -58,6 +58,9 @@ phone_accel_df = spark.read.format("csv").option("header", "true").load("dbfs:/h
 from tempo import * 
 
 phone_accel_tsdf = TSDF(phone_accel_df, ts_col="event_ts", partition_cols = ["User"])
+
+display(phone_accel_tsdf)
+
 ```
 
 #### 1. Resample and Visualize
@@ -104,9 +107,11 @@ watch_accel_df = spark.read.format("csv").option("header", "true").load("dbfs:/h
 watch_accel_tsdf = TSDF(watch_accel_df, ts_col="event_ts", partition_cols = ["User"])
 
 # Applying AS OF join to TSDF datasets
-joined_df = watch_accel_tsdf.asofJoin(phone_accel_tsdf, right_prefix="phone_accel").df
+joined_df = watch_accel_tsdf.asofJoin(phone_accel_tsdf, right_prefix="phone_accel")
 
-joined_df.show(10, False)
+display(joined_df)
+# We can use show() also 
+# joined_df.show(10, False)
 ```
 
 #### 3. Skew Join Optimized AS OF Join
@@ -122,8 +127,11 @@ fraction = overlap fraction
 right_prefix = prefix used for source columns when merged into fact table
 
 ```python
-joined_df = watch_accel_tsdf.asofJoin(phone_accel_tsdf, right_prefix="watch_accel", tsPartitionVal = 10, fraction = 0.1).df
-joined_df.show(10, False)
+joined_df = watch_accel_tsdf.asofJoin(phone_accel_tsdf, right_prefix="watch_accel", tsPartitionVal = 10, fraction = 0.1)
+
+display(joined_df)
+# We can use show() also
+# joined_df.show(10, False)
 ```
 
 #### 4 - Approximate Exponential Moving Average
@@ -135,8 +143,11 @@ Parameters:
 window = number of lagged values to compute for moving average
 
 ```python
-ema_trades = watch_accel_tsdf.EMA("x", window = 50).df
-ema_trades.show(10, False)
+ema_trades = watch_accel_tsdf.EMA("x", window = 50)
+
+display(ema_trades)
+# We can use show() also
+# ema_trades.show(10, False)
 ```
 
 #### 5 - Simple Moving Average
@@ -148,7 +159,7 @@ Parameters:
 rangeBackWindowSecs = number of seconds to look back
 
 ```python
-moving_avg = watch_accel_tsdf.withRangeStats("y", rangeBackWindowSecs=600).df
+moving_avg = watch_accel_tsdf.withRangeStats("y", rangeBackWindowSecs=600)
 moving_avg.select('event_ts', 'x', 'y', 'z', 'mean_y').show(10, False)
 ```
 

--- a/python/README.md
+++ b/python/README.md
@@ -14,13 +14,13 @@ The purpose of this project is to make time series manipulation with Spark simpl
 
 Python - pip install in Databricks notebooks using:
 
-```
+```shell
 %pip install dbl-tempo
 ```
 
 Install locally using: 
 
-```
+```shell
 pip install dbl-tempo
 ```
 
@@ -38,7 +38,7 @@ The entry point into all features for time series analysis in tempo is a TSDF ob
 
 Data source is UCI public accelerometer data available at this URL https://archive.ics.uci.edu/ml/datasets/Heterogeneity+Activity+Recognition
 
-#### 0. Read in Data 
+#### 0. Read in Data and display it 
 
 ```python
 from pyspark.sql.functions import * 
@@ -48,6 +48,8 @@ phone_accel_df = spark.read.format("csv").option("header", "true").load("dbfs:/h
 from tempo import * 
 
 phone_accel_tsdf = TSDF(phone_accel_df, ts_col="event_ts", partition_cols = ["User"])
+
+display(phone_accel_tsdf)
 ```
 
 #### 1. Resample and Visualize
@@ -94,9 +96,9 @@ watch_accel_df = spark.read.format("csv").option("header", "true").load("dbfs:/h
 watch_accel_tsdf = TSDF(watch_accel_df, ts_col="event_ts", partition_cols = ["User"])
 
 # Applying AS OF join to TSDF datasets
-joined_df = watch_accel_tsdf.asofJoin(phone_accel_tsdf, right_prefix="phone_accel").df
+joined_df = watch_accel_tsdf.asofJoin(phone_accel_tsdf, right_prefix="phone_accel")
 
-joined_df.show(10, False)
+display(joined_df)
 ```
 
 #### 3. Skew Join Optimized AS OF Join
@@ -112,8 +114,8 @@ fraction = overlap fraction
 right_prefix = prefix used for source columns when merged into fact table
 
 ```python
-joined_df = watch_accel_tsdf.asofJoin(phone_accel_tsdf, right_prefix="watch_accel", tsPartitionVal = 10, fraction = 0.1).df
-joined_df.show(10, False)
+joined_df = watch_accel_tsdf.asofJoin(phone_accel_tsdf, right_prefix="watch_accel", tsPartitionVal = 10, fraction = 0.1)
+display(joined_df)
 ```
 
 #### 4 - Approximate Exponential Moving Average
@@ -125,8 +127,8 @@ Parameters:
 window = number of lagged values to compute for moving average
 
 ```python
-ema_trades = watch_accel_tsdf.EMA("x", window = 50).df
-ema_trades.show(10, False)
+ema_trades = watch_accel_tsdf.EMA("x", window = 50)
+display(ema_trades)
 ```
 
 #### 5 - Simple Moving Average
@@ -138,7 +140,7 @@ Parameters:
 rangeBackWindowSecs = number of seconds to look back
 
 ```python
-moving_avg = watch_accel_tsdf.withRangeStats("y", rangeBackWindowSecs=600).df
+moving_avg = watch_accel_tsdf.withRangeStats("y", rangeBackWindowSecs=600)
 moving_avg.select('event_ts', 'x', 'y', 'z', 'mean_y').show(10, False)
 ```
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,3 +7,4 @@ python-dateutil==2.8.1
 pytz==2020.1
 six==1.15.0
 wheel==0.34.2
+ipython==7.28.0

--- a/python/tempo/__init__.py
+++ b/python/tempo/__init__.py
@@ -1,1 +1,2 @@
 from tempo.tsdf import TSDF
+from tempo.utils import display

--- a/python/tempo/utils.py
+++ b/python/tempo/utils.py
@@ -1,0 +1,87 @@
+from IPython.display import display as ipydisplay
+from IPython.core.display import HTML
+from IPython import get_ipython
+import os
+import logging
+from pyspark.sql.dataframe import DataFrame
+
+
+logger = logging.getLogger(__name__)
+PLATFORM = "DATABRICKS" if "DATABRICKS_RUNTIME_VERSION" in os.environ.keys() else "NON_DATABRICKS"
+"""
+This constant is to ensure the correct behaviour of the show and display methods are called based on the platform 
+where the code is running from. 
+"""
+
+def __isnotebookenv():
+    """
+    This method returns a boolean value signifying whether the environment is a notebook environment
+    capable of rendering HTML or not.
+    """
+    try:
+        shell = get_ipython().__class__.__name__
+        if shell == "ZMQInteractiveShell":
+            return True  # Jupyter notebook or qtconsole
+        elif shell == "TerminalInteractiveShell":
+            return False  # Terminal running IPython
+        else:
+            return False  # Other type (?)
+    except NameError:
+        return False
+
+def display_html(df):
+    """
+    Display method capable of displaying the dataframe in a formatted HTML structured output
+    """
+    ipydisplay(HTML("<style>pre { white-space: pre !important; }</style>"))
+    if isinstance(df,DataFrame):
+        df.show(truncate=False, vertical=False)
+    elif isinstance(df, pandasDataFrame):
+        df.head()
+    else:
+        logger.error("'display' method not available for this object")
+
+def display_unavailable(df):
+    """
+    This method is called when display method is not available in the environment.
+    """
+    logger.error("'display' method not available in this environment. Use 'show' method instead.")
+
+ENV_BOOLEAN = __isnotebookenv()
+
+if PLATFORM == "DATABRICKS":
+    method = get_ipython().user_ns['display']
+    # Under 'display' key in user_ns the original databricks display method is present
+    # to know more refer: /databricks/python_shell/scripts/db_ipykernel_launcher.py
+    def display_improvised(obj):
+        if type(obj).__name__ == 'TSDF':
+            method(obj.df)
+        else:
+            method(obj)
+    display = display_improvised
+elif __isnotebookenv():
+    def display_html_improvised(obj):
+        if type(obj).__name__ == 'TSDF':
+            display_html(obj.df)
+        else:
+            display_html(obj)
+    display = display_html_improvised
+else:    
+    display = display_unavailable
+
+"""
+display method's equivalent for TSDF object
+
+Example to show usage
+---------------------
+from pyspark.sql.functions import *
+
+phone_accel_df = spark.read.format("csv").option("header", "true").load("dbfs:/home/tempo/Phones_accelerometer").withColumn("event_ts", (col("Arrival_Time").cast("double")/1000).cast("timestamp")).withColumn("x", col("x").cast("double")).withColumn("y", col("y").cast("double")).withColumn("z", col("z").cast("double")).withColumn("event_ts_dbl", col("event_ts").cast("double"))
+
+from tempo import *
+
+phone_accel_tsdf = TSDF(phone_accel_df, ts_col="event_ts", partition_cols = ["User"])
+
+# Calling display method here
+display(phone_accel_tsdf)
+"""


### PR DESCRIPTION
… method for TSDF similar to normal Dataframes (#95)

* Added the standard show and display methods for TSDF objects for different environments

* Added the show and display method's docstrings and how to use them description

* adding separate utils file for the display functionality plus adding it to the import of tempo and updated requirements

* removed environment HTML rendering capability boolean from tsdf to utils as a constant which can be imported

* modified the init script according to PEP-8 convention

* correcting import of tempo.utils

* Fixed the display method to work with TSDF with the instance check

* Removed cyclic import dependency

* Removed cyclic import dependency of TSDF object being imported in utils leading to ENV_BOOLEAN and PLATFORM being problematic

* Recursive depth limit reached fix 1

* Replaced show method with display

Show method is available in case anyone curious wants to use it but we want to use the show only if display is not available.

* Commented show methods in the main readme and introduced display

* display unavailable case message handled

* display unavailable case message handled

* TSDF's select method added

* corrected select behaviour of params

* corrected the display message

* removing .df for select statement

* Removing .df from the select statement's use

* Corrected the documentation of the select method

* Update utils.py

* Removed flip the table art from the error messages.

* remove all print statements

Co-authored-by: Ricardo Portilla <ricardo.portilla@databricks.com>